### PR TITLE
Goto point, rectangle cleaning, performance improvements

### DIFF
--- a/custom_components/weback_vacuum/VacDevice.py
+++ b/custom_components/weback_vacuum/VacDevice.py
@@ -237,3 +237,22 @@ class VacDevice(WebackWssCtrl):
             room_data.append(dict(room_id = id))
         working_payload = {self.ASK_STATUS: self.CLEAN_MODE_ROOMS, self.SELECTED_ZONE: room_data}
         await self.send_command(self.name, self.sub_type, working_payload)
+
+    async def clean_zone(self, bounding):
+        box_x = []
+        box_y = []
+        num_boxes = len(bounding)
+
+        for box in bounding:
+            box_x.append(int(box[0]  / 10))
+            box_x.append(int(box[0]  / 10))
+            box_x.append(int(box[2]  / 10))
+            box_x.append(int(box[2]  / 10))
+            box_y.append(int(box[1]  / 10))
+            box_y.append(int(box[3]  / 10))
+            box_y.append(int(box[3]  / 10))
+            box_y.append(int(box[1]  / 10))
+        
+        working_payload = {self.ASK_STATUS: self.ROBOT_PLANNING_RECT, self.PLANNING_RECT_POINT_NUM: num_boxes * 4, self.PLANNING_RECT_X: box_x, self.PLANNING_RECT_Y: box_y}
+        _LOGGER.debug(f"Vacuum : Planning rect sent {working_payload}")
+        await self.send_command(self.name, self.sub_type, working_payload)

--- a/custom_components/weback_vacuum/VacDevice.py
+++ b/custom_components/weback_vacuum/VacDevice.py
@@ -17,6 +17,7 @@ class VacDevice(WebackWssCtrl):
         self.sub_type = sub_type
         self.map = None
         self.map_image_buffer = None
+        self.map_camera = None
 
         # First init status from HTTP API
         if self.robot_status is None:
@@ -56,7 +57,18 @@ class VacDevice(WebackWssCtrl):
         img.close()
         self.map_image_buffer = img_byte_arr.getvalue()
 
+        if self.map_camera is not None:
+            self.should_poll = False
+            self.trigger_map_camera_update()
+
         return True
+
+    def register_map_camera(self, camera):
+        self.map_camera = camera
+
+    def trigger_map_camera_update(self):
+        if self.map_camera is not None:
+            self.map_camera.schedule_update_ha_state(True)
 
     # ==========================================================
     # Vacuum Entity

--- a/custom_components/weback_vacuum/VacMap.py
+++ b/custom_components/weback_vacuum/VacMap.py
@@ -34,7 +34,7 @@ class VacMapDraw:
         for room in rooms:
             self.draw_room(room)
 
-    def draw_path(self, col = (0x1C, 0xE3, 0xDA, 0xFF)):
+    def draw_path(self, col = (0x1C, 0xE3, 0xDA, 0xFF), invisible_relocate = True):
         path, point_types = self.vac_map.get_path()
 
         last_coord = None
@@ -45,8 +45,8 @@ class VacMapDraw:
                 continue
 
             point_type = point_types[i]
-            
-            self.draw.line((last_coord, coord), col if point_type == VacMap.PATH_VACUUMING else (255,255,255,0), width=3)
+            if(point_type == VacMap.PATH_VACUUMING or invisible_relocate is False):
+                self.draw.line((last_coord, coord), col if point_type == VacMap.PATH_VACUUMING else (255,255,255,0), width=3)
 
             last_coord = coord        
 

--- a/custom_components/weback_vacuum/WebackApi.py
+++ b/custom_components/weback_vacuum/WebackApi.py
@@ -387,7 +387,7 @@ class WebackWssCtrl(WebackApi):
     CLEANING_STATES = {
         DIRECTION_CONTROL, ROBOT_PLANNING_RECT, RELOCATION, CLEAN_MODE_Z, CLEAN_MODE_AUTO,
         CLEAN_MODE_EDGE, CLEAN_MODE_EDGE_DETECT, CLEAN_MODE_SPOT, CLEAN_MODE_SINGLE_ROOM,
-        CLEAN_MODE_ROOMS, CLEAN_MODE_MOP, CLEAN_MODE_SMART
+        CLEAN_MODE_ROOMS, CLEAN_MODE_MOP, CLEAN_MODE_SMART, CHARGE_MODE_RETURNING
     }
 
     CHARGING_STATES = {
@@ -408,7 +408,7 @@ class WebackWssCtrl(WebackApi):
     PLANNING_RECT_POINT_NUM = "planning_rect_point_num"
     PLANNING_RECT_X = "planning_rect_x"
     PLANNING_RECT_Y = "planning_rect_y"
-    
+
     # Payload switches
     VOICE_SWITCH = "voice_switch"
     UNDISTURB_MODE = "undisturb_mode"
@@ -547,6 +547,7 @@ class WebackWssCtrl(WebackApi):
             _LOGGER.debug(f"WebackApi (WSS) Map data received")
             self.map.wss_update(wss_data['map_data'])
             self.render_map()
+            self.adapt_refresh_time(self.robot_status)
             self._call_subscriber()
         else:
             _LOGGER.error(f"WebackApi (WSS) Received an unknown message from server : {wss_data}")

--- a/custom_components/weback_vacuum/WebackApi.py
+++ b/custom_components/weback_vacuum/WebackApi.py
@@ -405,6 +405,10 @@ class WebackWssCtrl(WebackApi):
     RECTANGLE_INFO = "virtual_rect_info"
     SPEAKER_VOLUME = "volume"
     SELECTED_ZONE = "selected_zone"
+    PLANNING_RECT_POINT_NUM = "planning_rect_point_num"
+    PLANNING_RECT_X = "planning_rect_x"
+    PLANNING_RECT_Y = "planning_rect_y"
+    
     # Payload switches
     VOICE_SWITCH = "voice_switch"
     UNDISTURB_MODE = "undisturb_mode"

--- a/custom_components/weback_vacuum/camera.py
+++ b/custom_components/weback_vacuum/camera.py
@@ -29,7 +29,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     for device in hass.data[DOMAIN]:
         entity_id = generate_entity_id(ENTITY_ID_FORMAT, device.name, hass=hass)
         vacuums.append(WebackVacuumCamera(device, entity_id))
-        hass.loop.create_task(device.watch_state())
+        # hass.loop.create_task(device.watch_state())
     
     _LOGGER.debug("Adding Weback Vacuums Maps to Home Assistant: %s", vacuums)
 

--- a/custom_components/weback_vacuum/camera.py
+++ b/custom_components/weback_vacuum/camera.py
@@ -43,6 +43,7 @@ class WebackVacuumCamera(Camera):
         """Initialize the Weback Vacuum Map"""
         super().__init__()
         self._vacdevice = device
+        self._vacdevice.register_map_camera(self)
         # self.entity_id = entity_id
         self.content_type = "image/png"
         

--- a/custom_components/weback_vacuum/vacuum.py
+++ b/custom_components/weback_vacuum/vacuum.py
@@ -300,5 +300,9 @@ class WebackVacuumRobot(StateVacuumEntity):
         _LOGGER.debug(f"Vacuum: send_command (command={command} / params={params} / kwargs={kwargs})")
         if(command == 'app_segment_clean'):
             await self.device.clean_room(params)
+        elif(command == 'app_zoned_clean'):
+            await self.device.clean_zone(params)
+        elif(command == 'app_goto_target'):
+            await self.device.goto([int(params[0] / 10), int(params[1] / 10)])
         else:
             await self.device.send_command(self.name, self.sub, params)


### PR DESCRIPTION
- Feature: Rectangle Cleaning
- Feature: Goto Point
- Fix: Do not draw relocating path (now similar to Weback app behaviour)
- Fix: Two Websocket threads were active, one for camera, one for vacuum. Now 1 is shared.
- Performance: Adapt refresh time in response to map data
- Performance: Do not sleep event loop for full `_refresh_time`, sleep for 5s always but check timestamp for overdue update_status() call. Fixes 120s wait when device transitions from non-cleaning to cleaning mode.
- Performance: Map camera now pushes updates, does not rely on polling