### PR TITLE
Fix for #11 - Property existance not checked correctly

### DIFF
--- a/custom_components/weback_vacuum/VacDevice.py
+++ b/custom_components/weback_vacuum/VacDevice.py
@@ -37,7 +37,7 @@ class VacDevice(WebackWssCtrl):
     async def load_maps(self):
         """Load the current reuse map"""
 
-        if not self.robot_status[self.ACTIVE_MAP_ID_PROP]:
+        if self.ACTIVE_MAP_ID_PROP not in self.robot_status:
             return False
 
         map_data = await self.get_reuse_map_by_id(self.robot_status[self.ACTIVE_MAP_ID_PROP], self.sub_type, self.name)


### PR DESCRIPTION
This is a fix for the bug I introduced in the last commit.

This should fix the error when `hismap_id` is missing.

@Jezza34000 - Please could you release this as `1.1.2`?


