### PR TITLE
Fix time reporting on x-styleb

### DIFF
--- a/custom_components/weback_vacuum/vacuum.py
+++ b/custom_components/weback_vacuum/vacuum.py
@@ -49,6 +49,12 @@ STATE_MAPPING = {
     VacDevice.ROBOT_ERROR: STATE_ERROR,
 }
 
+# Some models report time in minutes, not seconds, we need to adjust
+# calculations for them.
+SUB_TYPES_REPORTING_MINUTES = [
+    "x-styleb",
+]
+
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Weback robot vacuums."""
@@ -233,7 +239,10 @@ class WebackVacuumRobot(StateVacuumEntity):
             clean_time = self.device.robot_status["clean_time"]
             if clean_time is None:
                 clean_time = 0
-            extra_value["clean_time"] = (round(clean_time / 60, 0),)
+            if self.device.sub_type in SUB_TYPES_REPORTING_MINUTES:
+                extra_value["clean_time"] = (clean_time,)
+            else:
+                extra_value["clean_time"] = (round(clean_time / 60, 0),)
 
         return extra_value
 


### PR DESCRIPTION
Apparently my x-styleb reports clean time in minutes, not seconds. This means that I get wrong values. This commit fixes this by introducing a list of devices that report `clean_time` in minutes and for them it does not divide the value by 60.